### PR TITLE
Use correct folder type ids instead of asset ids for inventory folders

### DIFF
--- a/OpenMetaverse/AppearanceManager.cs
+++ b/OpenMetaverse/AppearanceManager.cs
@@ -1910,7 +1910,7 @@ namespace OpenMetaverse
             {
                 foreach (InventoryBase baseItem in root)
                 {
-                    if (baseItem is InventoryFolder && ((InventoryFolder)baseItem).PreferredType == AssetType.CurrentOutfitFolder)
+                    if (baseItem is InventoryFolder && ((InventoryFolder)baseItem).PreferredType == FolderType.CurrentOutfit)
                     {
                         COF = (InventoryFolder)baseItem;
                         break;

--- a/OpenMetaverse/Assets/Archiving/ArchiveConstants.cs
+++ b/OpenMetaverse/Assets/Archiving/ArchiveConstants.cs
@@ -86,19 +86,15 @@ namespace OpenMetaverse.Assets
             ASSET_TYPE_TO_EXTENSION[AssetType.ImageJPEG] = ASSET_EXTENSION_SEPARATOR + "image.jpg";
             ASSET_TYPE_TO_EXTENSION[AssetType.ImageTGA] = ASSET_EXTENSION_SEPARATOR + "image.tga";
             ASSET_TYPE_TO_EXTENSION[AssetType.Landmark] = ASSET_EXTENSION_SEPARATOR + "landmark.txt";
-            ASSET_TYPE_TO_EXTENSION[AssetType.LostAndFoundFolder] = ASSET_EXTENSION_SEPARATOR + "lostandfoundfolder.txt";   // Not sure if we'll ever see this
             ASSET_TYPE_TO_EXTENSION[AssetType.LSLBytecode] = ASSET_EXTENSION_SEPARATOR + "bytecode.lso";
             ASSET_TYPE_TO_EXTENSION[AssetType.LSLText] = ASSET_EXTENSION_SEPARATOR + "script.lsl";
             ASSET_TYPE_TO_EXTENSION[AssetType.Notecard] = ASSET_EXTENSION_SEPARATOR + "notecard.txt";
             ASSET_TYPE_TO_EXTENSION[AssetType.Object] = ASSET_EXTENSION_SEPARATOR + "object.xml";
-            ASSET_TYPE_TO_EXTENSION[AssetType.RootFolder] = ASSET_EXTENSION_SEPARATOR + "rootfolder.txt";   // Not sure if we'll ever see this
             ASSET_TYPE_TO_EXTENSION[AssetType.Simstate] = ASSET_EXTENSION_SEPARATOR + "simstate.bin";   // Not sure if we'll ever see this
-            ASSET_TYPE_TO_EXTENSION[AssetType.SnapshotFolder] = ASSET_EXTENSION_SEPARATOR + "snapshotfolder.txt";   // Not sure if we'll ever see this
             ASSET_TYPE_TO_EXTENSION[AssetType.Sound] = ASSET_EXTENSION_SEPARATOR + "sound.ogg";
             ASSET_TYPE_TO_EXTENSION[AssetType.SoundWAV] = ASSET_EXTENSION_SEPARATOR + "sound.wav";
             ASSET_TYPE_TO_EXTENSION[AssetType.Texture] = ASSET_EXTENSION_SEPARATOR + "texture.jp2";
             ASSET_TYPE_TO_EXTENSION[AssetType.TextureTGA] = ASSET_EXTENSION_SEPARATOR + "texture.tga";
-            ASSET_TYPE_TO_EXTENSION[AssetType.TrashFolder] = ASSET_EXTENSION_SEPARATOR + "trashfolder.txt";   // Not sure if we'll ever see this
 
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "animation.bvh"] = AssetType.Animation;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "bodypart.txt"] = AssetType.Bodypart;
@@ -109,19 +105,15 @@ namespace OpenMetaverse.Assets
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "image.jpg"] = AssetType.ImageJPEG;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "image.tga"] = AssetType.ImageTGA;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "landmark.txt"] = AssetType.Landmark;
-            EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "lostandfoundfolder.txt"] = AssetType.LostAndFoundFolder;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "bytecode.lso"] = AssetType.LSLBytecode;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "script.lsl"] = AssetType.LSLText;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "notecard.txt"] = AssetType.Notecard;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "object.xml"] = AssetType.Object;
-            EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "rootfolder.txt"] = AssetType.RootFolder;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "simstate.bin"] = AssetType.Simstate;
-            EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "snapshotfolder.txt"] = AssetType.SnapshotFolder;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "sound.ogg"] = AssetType.Sound;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "sound.wav"] = AssetType.SoundWAV;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "texture.jp2"] = AssetType.Texture;
             EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "texture.tga"] = AssetType.TextureTGA;
-            EXTENSION_TO_ASSET_TYPE[ASSET_EXTENSION_SEPARATOR + "trashfolder.txt"] = AssetType.TrashFolder;
         }
     }
 }

--- a/OpenMetaverse/Login.cs
+++ b/OpenMetaverse/Login.cs
@@ -719,7 +719,7 @@ namespace OpenMetaverse
                     {
                         OSDMap map = (OSDMap)array[i];
                         InventoryFolder folder = new InventoryFolder(map["folder_id"].AsUUID());
-                        folder.PreferredType = (AssetType)map["type_default"].AsInteger();
+                        folder.PreferredType = (FolderType)map["type_default"].AsInteger();
                         folder.Version = map["version"].AsInteger();
                         folder.OwnerID = owner;
                         folder.ParentUUID = map["parent_id"].AsUUID();
@@ -749,7 +749,7 @@ namespace OpenMetaverse
                         InventoryFolder folder = new InventoryFolder(map["folder_id"].AsUUID());
                         folder.Name = map["name"].AsString();
                         folder.ParentUUID = map["parent_id"].AsUUID();
-                        folder.PreferredType = (AssetType)map["type_default"].AsInteger();
+                        folder.PreferredType = (FolderType)map["type_default"].AsInteger();
                         folder.Version = map["version"].AsInteger();
                         folders.Add(folder);
                     }
@@ -779,7 +779,7 @@ namespace OpenMetaverse
                         InventoryFolder folder = new InventoryFolder(ParseUUID("folder_id", map));
                         folder.Name = ParseString("name", map);
                         folder.ParentUUID = ParseUUID("parent_id", map);
-                        folder.PreferredType = (AssetType)ParseUInt("type_default", map);
+                        folder.PreferredType = (FolderType)ParseUInt("type_default", map);
                         folder.Version = (int)ParseUInt("version", map);
                         folder.OwnerID = ownerID;
 

--- a/OpenMetaverse/Messages/LindenMessages.cs
+++ b/OpenMetaverse/Messages/LindenMessages.cs
@@ -1352,7 +1352,7 @@ namespace OpenMetaverse.Messages.Linden
             public UUID FolderID;
             public UUID ParentID;
             public string Name;
-            public AssetType Type;
+            public FolderType Type;
 
             public static FolderDataInfo FromOSD(OSD data)
             {
@@ -1365,7 +1365,7 @@ namespace OpenMetaverse.Messages.Linden
                 ret.FolderID = map["FolderID"];
                 ret.ParentID = map["ParentID"];
                 ret.Name = map["Name"];
-                ret.Type = (AssetType)map["Type"].AsInteger();
+                ret.Type = (FolderType)map["Type"].AsInteger();
                 return ret;
             }
         }

--- a/OpenMetaverse/PacketDecoder.cs
+++ b/OpenMetaverse/PacketDecoder.cs
@@ -1070,10 +1070,10 @@ namespace OpenMetaverse.Packets
 
         private static string DecodeFolderType(string fieldName, object fieldData)
         {
-            return String.Format("{0,30}: {1,-2} {2,-37} [AssetType]",
+            return String.Format("{0,30}: {1,-2} {2,-37} [Folderype]",
                                  fieldName,
                                  (sbyte)fieldData,
-                                 "(" + (AssetType)fieldData + ")");
+                                 "(" + (FolderType)fieldData + ")");
         }
 
         private static string DecodeInventoryFlags(string fieldName, object fieldData)

--- a/OpenMetaverseTypes/Enums.cs
+++ b/OpenMetaverseTypes/Enums.cs
@@ -64,33 +64,23 @@ namespace OpenMetaverse
         // <summary>Legacy script asset, you should never see one of these</summary>
         //[Obsolete]
         //Script = 4,
-        /// <summary>Collection of textures and parameters that can be 
-        /// worn by an avatar</summary>
+        /// <summary>Collection of textures and parameters that can be worn by an avatar</summary>
         Clothing = 5,
         /// <summary>Primitive that can contain textures, sounds, 
         /// scripts and more</summary>
         Object = 6,
         /// <summary>Notecard asset</summary>
         Notecard = 7,
-        /// <summary>Holds a collection of inventory items</summary>
+        /// <summary>Holds a collection of inventory items. "Category" in the Linden viewer</summary>
         Folder = 8,
-        /// <summary>Root inventory folder</summary>
-        RootFolder = 9,
         /// <summary>Linden scripting language script</summary>
         LSLText = 10,
         /// <summary>LSO bytecode for a script</summary>
         LSLBytecode = 11,
         /// <summary>Uncompressed TGA texture</summary>
         TextureTGA = 12,
-        /// <summary>Collection of textures and shape parameters that can
-        /// be worn</summary>
+        /// <summary>Collection of textures and shape parameters that can be worn</summary>
         Bodypart = 13,
-        /// <summary>Trash folder</summary>
-        TrashFolder = 14,
-        /// <summary>Snapshot folder</summary>
-        SnapshotFolder = 15,
-        /// <summary>Lost and found folder</summary>
-        LostAndFoundFolder = 16,
         /// <summary>Uncompressed sound</summary>
         SoundWAV = 17,
         /// <summary>Uncompressed TGA non-square image, not to be used as a
@@ -105,33 +95,77 @@ namespace OpenMetaverse
         Gesture = 21,
         /// <summary>Simstate file</summary>
         Simstate = 22,
-        /// <summary>Contains landmarks for favorites</summary>
-        FavoriteFolder = 23,
         /// <summary>Asset is a link to another inventory item</summary>
         Link = 24,
         /// <summary>Asset is a link to another inventory folder</summary>
         LinkFolder = 25,
-        /// <summary>Beginning of the range reserved for ensembles</summary>
-        EnsembleStart = 26,
-        /// <summary>End of the range reserved for ensembles</summary>
-        EnsembleEnd = 45,
-        /// <summary>Folder containing inventory links to wearables and attachments
-        /// that are part of the current outfit</summary>
-        CurrentOutfitFolder = 46,
-        /// <summary>Folder containing inventory items or links to
-        /// inventory items of wearables and attachments
-        /// together make a full outfit</summary>
-        OutfitFolder = 47,
-        /// <summary>Root folder for the folders of type OutfitFolder</summary>
-        MyOutfitsFolder = 48,
+        /// <summary>Marketplace Folder. Same as an Category but different display methods.</summary>
+        MarketplaceFolder = 26,
         /// <summary>Linden mesh format</summary>
+        Mesh = 49,
+    }
+
+    /// <summary>
+    /// The different types of folder.
+    /// </summary>
+    public enum FolderType : sbyte
+    {
+        /// <summary>None folder type</summary>
+        None = -1,
+        /// <summary>Texture folder type</summary>
+        Texture = 0,
+        /// <summary>Sound folder type</summary>
+        Sound = 1,
+        /// <summary>Calling card folder type</summary>
+        CallingCard = 2,
+        /// <summary>Landmark folder type</summary>
+        Landmark = 3,
+        /// <summary>Clothing folder type</summary>
+        Clothing = 5,
+        /// <summary>Object folder type</summary>
+        Object = 6,
+        /// <summary>Notecard folder type</summary>
+        Notecard = 7,
+        /// <summary>The root folder type</summary>
+        Root = 8,
+        /// <summary>LSLText folder</summary>
+        LSLText = 10,
+        /// <summary>Bodyparts folder</summary>
+        BodyPart = 13,
+        /// <summary>Trash folder</summary>
+        Trash = 14,
+        /// <summary>Snapshot folder</summary>
+        Snapshot = 15,
+        /// <summary>Lost And Found folder</summary>
+        LostAndFound = 16,
+        /// <summary>Animation folder</summary>
+        Animation = 20,
+        /// <summary>Gesture folder</summary>
+        Gesture = 21,
+        /// <summary>Favorites folder</summary>
+        Favorites = 23,
+        /// <summary>Ensemble beginning range</summary>
+        EnsembleStart = 26,
+        /// <summary>Ensemble ending range</summary>
+        EnsembleEnd= 45,
+        /// <summary>Current outfit folder</summary>
+        CurrentOutfit = 46,
+        /// <summary>Outfit folder</summary>
+        Outfit = 47,
+        /// <summary>My outfits folder</summary>
+        MyOutfits = 48,
+        /// <summary>Mesh folder</summary>
         Mesh = 49,
         /// <summary>Marketplace direct delivery inbox ("Received Items")</summary>
         Inbox = 50,
         /// <summary>Marketplace direct delivery outbox</summary>
         Outbox = 51,
-        /// <summary></summary>
-        BasicRoot = 51,
+        /// <summary>Basic root folder</summary>
+        BasicRoot = 52,
+        /// <summary>Marketplace listings folder</summary>
+        MarketplaceListings = 53,
+        /// <summary>Marketplace stock folder</summary>
+        MarkplaceStock = 54
     }
 
     /// <summary>

--- a/OpenMetaverseTypes/UtilsConversions.cs
+++ b/OpenMetaverseTypes/UtilsConversions.cs
@@ -46,24 +46,24 @@ namespace OpenMetaverse
 	        "object",     //  6
 	        "notecard",   //  7
 	        "category",   //  8
-	        "root",       //  9
+	        String.Empty, //  9
 	        "lsltext",    // 10
 	        "lslbyte",    // 11
 	        "txtr_tga",   // 12
 	        "bodypart",   // 13
-	        "trash",      // 14
-	        "snapshot",   // 15
-	        "lstndfnd",   // 16
+	        String.Empty, // 14
+	        String.Empty, // 15
+	        String.Empty, // 16
 	        "snd_wav",    // 17
 	        "img_tga",    // 18
 	        "jpeg",       // 19
 	        "animatn",    // 20
 	        "gesture",    // 21
 	        "simstate",   // 22
-            "favorite",   // 23
+            String.Empty, // 23
             "link",       // 24
             "linkfolder", // 25
-            String.Empty, // 26
+            "marketplacefolder", // 26
             String.Empty, // 27
             String.Empty, // 28
             String.Empty, // 29
@@ -83,10 +83,69 @@ namespace OpenMetaverse
             String.Empty, // 43
             String.Empty, // 44
             String.Empty, // 45
-            "curoutfit",  // 46
-            "outfit",     // 47
-            "myoutfits",  // 48
+            String.Empty, // 46
+            String.Empty, // 47
+            String.Empty, // 48
             "mesh",       // 49
+        };
+
+        private static readonly string[] _FolderTypeNames = new string[]
+        {
+            "texture",    //  0
+            "sound",      //  1
+            "callcard",   //  2
+            "landmark",   //  3
+            String.Empty, //  4
+            "clothing",   //  5
+            "object",     //  6
+            "notecard",   //  7
+            "root_inv",   //  8
+            String.Empty, //  9
+            "lsltext",    // 10
+            String.Empty, // 11
+            String.Empty, // 12
+            "bodypart",   // 13
+            "trash",      // 14
+            "snapshot",   // 15
+            "lstndfnd",   // 16
+            String.Empty, // 17
+            String.Empty, // 18
+            String.Empty, // 19
+            "animatn",    // 20
+            "gesture",    // 21
+            String.Empty, // 22
+            "favorite",   // 23
+            String.Empty, // 24
+            String.Empty, // 25
+            "ensemble",   // 26
+            "ensemble",   // 27
+            "ensemble",   // 28
+            "ensemble",   // 29
+            "ensemble",   // 30
+            "ensemble",   // 31
+            "ensemble",   // 32
+            "ensemble",   // 33
+            "ensemble",   // 34
+            "ensemble",   // 35
+            "ensemble",   // 36
+            "ensemble",   // 37
+            "ensemble",   // 38
+            "ensemble",   // 39
+            "ensemble",   // 40
+            "ensemble",   // 41
+            "ensemble",   // 42
+            "ensemble",   // 43
+            "ensemble",   // 44
+            "ensemble",   // 45
+            "current",    // 46
+            "outfit",     // 47
+            "my_otfts",   // 48
+            "mesh",       // 49
+            "inbox",      // 50
+            "outbox",     // 51
+            "basic_rt",   // 52
+            "merchant",   // 53
+            "stock",      // 54
         };
 
         private static readonly string[] _InventoryTypeNames = new string[]
@@ -947,6 +1006,32 @@ namespace OpenMetaverse
             }
 
             return AssetType.Unknown;
+        }
+
+        /// <summary>
+        /// Takes a FolderType and returns the string representation
+        /// </summary>
+        /// <param name="type">The source <seealso cref="FolderType"/></param>
+        /// <returns>The string version of the FolderType</returns>
+        public static string FolderTypeToString(FolderType type)
+        {
+            return _FolderTypeNames[(int)type];
+        }
+
+        /// <summary>
+        /// Translate a string name of an FolderType into the proper Type
+        /// </summary>
+        /// <param name="type">A string containing the FolderType name</param>
+        /// <returns>The FolderType which matches the string name, or FolderType. None if no match was found</returns>
+        public static FolderType StringToFolderType(string type)
+        {
+            for (int i = 0; i < _FolderTypeNames.Length; i++)
+            {
+                if (_FolderTypeNames[i] == type)
+                    return (FolderType)i;
+            }
+
+            return FolderType.None;
         }
 
         /// <summary>

--- a/Programs/examples/TestClient/Commands/Inventory/DeleteFolderCommand.cs
+++ b/Programs/examples/TestClient/Commands/Inventory/DeleteFolderCommand.cs
@@ -38,7 +38,7 @@ namespace OpenMetaverse.TestClient
             if (found.Count.Equals(1))
             {
                 // move the folder to the trash folder
-                Client.Inventory.MoveFolder(found[0].UUID, Client.Inventory.FindFolderForType(AssetType.TrashFolder));
+                Client.Inventory.MoveFolder(found[0].UUID, Client.Inventory.FindFolderForType(FolderType.Trash));
                 
                 return String.Format("Moved folder {0} to Trash", found[0].Name);
             }

--- a/Programs/examples/TestClient/Commands/Prims/DeRezObjectCommand.cs
+++ b/Programs/examples/TestClient/Commands/Prims/DeRezObjectCommand.cs
@@ -29,7 +29,7 @@ namespace OpenMetaverse.TestClient
                 {
                     uint objectLocalID = target.LocalID;
                     Client.Inventory.RequestDeRezToInventory(objectLocalID, DeRezDestination.AgentInventoryTake,
-                                                             Client.Inventory.FindFolderForType(AssetType.TrashFolder),
+                                                             Client.Inventory.FindFolderForType(FolderType.Trash),
                                                              UUID.Random());
                     return "removing " + target;
                 }


### PR DESCRIPTION
This corrects a severe error where as AssetTypes were being reused for
the Folder FolderType id resulting in invalid ids for various system
folder types causing inventory validation issues from within the SL
viewer.