### PR TITLE
Fix [LIBOMV-985] Matrix4.Inverse fails to calculate the inverse of almost any matrix

### DIFF
--- a/OpenMetaverse.Tests/TypeTests.cs
+++ b/OpenMetaverse.Tests/TypeTests.cs
@@ -189,6 +189,32 @@ namespace OpenMetaverse.Tests
             Assert.IsTrue(result == expected, a.ToString() + " * " + b.ToString() + " produced " + result.ToString() +
                 " instead of " + expected.ToString());
         }
+        
+        [Test]
+        public void testMatrix()
+        {
+    	    Matrix4 matrix = new Matrix4(0, 0, 74, 1,
+				                         0, 435, 0, 1,
+				                         345, 0, 34, 1,
+				                         0, 0, 0, 0);
+    	
+    	    /* determinant of singular matrix returns zero */
+    	    Assert.AreEqual(0d, (double)matrix.Determinant(), 0.001d);
+    	
+    	    /* inverse of identity matrix is the identity matrix */
+       	    Assert.IsTrue(Matrix4.Identity == Matrix4.Inverse(Matrix4.Identity));
+  	 
+    	    /* inverse of non-singular matrix returns True And InverseMatrix */
+            matrix = new Matrix4(1, 1, 0, 0,
+    			    		     1, 1, 1, 0,
+    					         0, 1, 1, 0,
+    					         0, 0, 0, 1);
+    	    Matrix4 expectedInverse = new Matrix4(0, 1,-1, 0,
+    						                      1,-1, 1, 0,
+    						                     -1, 1, 0, 0,
+    						                      0, 0, 0, 1);
+    	    Assert.AreEqual(expectedInverse, Matrix4.Inverse(matrix));
+        }
 
         //[Test]
         //public void VectorQuaternionMath()

--- a/OpenMetaverseTypes/Matrix4.cs
+++ b/OpenMetaverseTypes/Matrix4.cs
@@ -161,7 +161,7 @@ namespace OpenMetaverse
             float det = 0f;
 
             float diag1 = M11 * M22 * M33;
-            float diag2 = M12 * M32 * M31;
+            float diag2 = M12 * M23 * M31;
             float diag3 = M13 * M21 * M32;
             float diag4 = M31 * M22 * M13;
             float diag5 = M32 * M23 * M11;
@@ -950,7 +950,7 @@ namespace OpenMetaverse
             for (int i = 0; i < 4; i++)
             {
                 for (int j = 0; j < 4; j++)
-                    adjointMatrix[i,j] = (float)(Math.Pow(-1, i + j) * ((Minor(matrix, i, j)).Determinant()));
+                    adjointMatrix[i,j] = (float)(Math.Pow(-1, i + j) * ((Minor(matrix, i, j)).Determinant3x3()));
             }
 
             adjointMatrix = Transpose(adjointMatrix);
@@ -986,12 +986,15 @@ namespace OpenMetaverse
 
         public override bool Equals(object obj)
         {
-            return (obj is Matrix4) ? this == (Matrix4)obj : false;
+            return (obj is Matrix4) ? this.Equals((Matrix4)obj) : false;
         }
 
         public bool Equals(Matrix4 other)
         {
-            return this == other;
+            return M11 == other.M11 && M12 == other.M12 && M13 == other.M13 && M14 == other.M14 &&
+                   M21 == other.M21 && M22 == other.M22 && M23 == other.M23 && M24 == other.M24 &&
+                   M31 == other.M31 && M32 == other.M32 && M33 == other.M33 && M14 == other.M34 &&
+                   M41 == other.M41 && M42 == other.M42 && M43 == other.M43 && M44 == other.M44;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
I'm sorry to hear about Latif's passing.

[LIBOMV-985] Matrix4.Inverse fails to calculate the inverse of almost any matrix
https://metaverse.atlassian.net/browse/LIBOMV-985

Over one year has passed since this issue posted on 23/11/14.
Matrix4.Inverse function is important function for Vertex skinning.
Please merge my pull request that applied the patch.