### PR TITLE
Debugging of Collada Loader, specifically texture handling.

### DIFF
--- a/OpenMetaverse/ImportExport/ColladalLoader.cs
+++ b/OpenMetaverse/ImportExport/ColladalLoader.cs
@@ -84,7 +84,7 @@ namespace OpenMetaverse.ImportExport
                 var prims = Parse();
                 if (loadImages)
                 {
-                    LoadImages(prims);
+                    LoadImages();
                 }
                 return prims;
             }
@@ -95,17 +95,14 @@ namespace OpenMetaverse.ImportExport
             }
         }
 
-        void LoadImages(List<ModelPrim> prims)
+        void LoadImages()
         {
-            foreach (var prim in prims)
+            foreach (var material in Materials)
             {
-                foreach (var face in prim.Faces)
-                {
-                    if (!string.IsNullOrEmpty(face.Material.Texture))
-                    {
-                        LoadImage(face.Material);
-                    }
-                }
+				if (!string.IsNullOrEmpty(material.Texture))
+				{
+					LoadImage(material);
+				}
             }
         }
 
@@ -202,7 +199,7 @@ namespace OpenMetaverse.ImportExport
             else if (diffuse is common_color_or_texture_typeTexture)
             {
                 var tex = (common_color_or_texture_typeTexture)diffuse;
-                ret.Texture = tex.texcoord;
+                ret.Texture = tex.texture;
             }
             return ret;
 
@@ -219,8 +216,68 @@ namespace OpenMetaverse.ImportExport
             Dictionary<string, string> matEffect = new Dictionary<string, string>();
             List<ModelMaterial> tmpEffects = new List<ModelMaterial>();
 
-            // Image ID -> filename mapping
+
+/*
+            // Here is how Collada works: Texture files are refered in four steps! Check ////////////// comments below.
+
+
+            <profile_COMMON>
+                ////////////////// Here is an <image> clause which binds its id to a file name (relative to some root)
+                // <image> clauses can be found both in <library_images>, in <effect> and in <profile_XXXX>. Hopefully identifiers
+                // are unique even in the latter cases, or this code won't work.
+                <image id="material_1_effect-image" height="0" width="0">
+                    <init_from>solar_panel_001.png</init_from>
+                </image>
+                ////////////////// Here is a definition of a surface. Typically bound to a <image> using <init_from> but can also be bound as a
+                // render target for a previous pass (or it would be a useless intermediate step).
+                <newparam sid="material_1_effect-surface">
+                    <surface type="2D">
+                        <init_from>material_1_effect-image</init_from>
+                    </surface>
+                </newparam>
+                ////////////////// A sampler defines some parameters for how the texture unit is to sample the underlying surface, which is refered
+                // to by the <source> element.
+                <newparam sid="material_1_effect-sampler">
+                    <sampler2D>
+                        <source>material_1_effect-surface</source>
+                        <wrap_s>WRAP</wrap_s>
+                        <wrap_t>WRAP</wrap_t>
+                        <minfilter>LINEAR_MIPMAP_LINEAR</minfilter>
+                        <magfilter>LINEAR</magfilter>
+                        <border_color>0 0 0 0</border_color>
+                    </sampler2D>
+                </newparam>
+                <technique sid="t0">
+                    <phong>
+                        <emission>
+                            <color>0 0 0 1</color>
+                        </emission>
+                        <ambient>
+                            <color>0 0 0 0</color>
+                        </ambient>
+                        <diffuse>
+                            //////////////// The texture itself refers to the sampelr by its 'texture' property.
+                            <texture texture="material_1_effect-sampler" texcoord="texcoord0"/>
+                        </diffuse>
+                        <specular>
+                            <color>0 0 0 1</color>
+                        </specular>
+                        <shininess>
+                            <float>50</float>
+                        </shininess>
+                    </phong>
+                </technique>
+            </profile_COMMON>
+
+*/
+
+
+            // Image id -> filename mapping (<init_from> field in <image>)
             Dictionary<string, string> imgMap = new Dictionary<string, string>();
+            // Surface sid to Image ID mapping (<init_from> field in <surface>)
+            Dictionary<string, string> surfaceMap = new Dictionary<string, string>();
+            // Sampler2D sid -> Surface ID mapping (<source> field in <sampler>)
+            Dictionary<string, string> samplerMap = new Dictionary<string, string>();
 
             foreach (var item in Model.Items)
             {
@@ -276,11 +333,39 @@ namespace OpenMetaverse.ImportExport
                             string ID = effect.id;
                             foreach (var effItem in effect.Items)
                             {
-                                if (effItem is effectFx_profile_abstractProfile_COMMON)
-                                {
-                                    var teq = ((effectFx_profile_abstractProfile_COMMON)effItem).technique;
-                                    if (teq != null)
-                                    {
+                                if (effItem is image) {
+                                    var img = (image)effItem;
+                                    string IMID = img.id;
+                                    if (img.Item is string)
+                                        imgMap[IMID] = (string)img.Item;
+                                }
+                                else if (effItem is effectFx_profile_abstractProfile_COMMON) {
+                                    var pc = (effectFx_profile_abstractProfile_COMMON)effItem;
+                                    if (pc.Items != null) {
+                                        foreach (var pcitem in pc.Items) {
+                                            if (pcitem is image) {
+                                                var img = (image)pcitem;
+                                                string IMID = img.id;
+                                                if (img.Item is string)
+                                                    imgMap[IMID] = (string)img.Item;
+                                            }
+                                            else if (pcitem is common_newparam_type) {
+                                                var newparam = (common_newparam_type)pcitem;
+                                                if (newparam.Item is fx_surface_common)
+                                                {
+                                                    var surface = (fx_surface_common)newparam.Item;
+                                                    surfaceMap[newparam.sid] = surface.init_from[0].Value;
+                                                }
+                                                else if (newparam.Item is fx_sampler2D_common)
+                                                {
+                                                    var sampler = (fx_sampler2D_common)newparam.Item;
+                                                    samplerMap[newparam.sid] = sampler.source;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    var teq = pc.technique;
+                                    if (teq != null) {
                                         if (teq.Item is effectFx_profile_abstractProfile_COMMONTechniquePhong)
                                         {
                                             var shader = (effectFx_profile_abstractProfile_COMMONTechniquePhong)teq.Item;
@@ -314,13 +399,20 @@ namespace OpenMetaverse.ImportExport
                 if (matEffect.ContainsKey(effect.ID))
                 {
                     effect.ID = matEffect[effect.ID];
-                    if (!string.IsNullOrEmpty(effect.Texture))
-                    {
-                        if (imgMap.ContainsKey(effect.Texture))
-                        {
-                            effect.Texture = imgMap[effect.Texture];
+
+                    if (!string.IsNullOrEmpty(effect.Texture)) {
+                        if (samplerMap.ContainsKey(effect.Texture)) {
+                            string surfaceId = samplerMap[effect.Texture];
+
+                            if (surfaceMap.ContainsKey(surfaceId)) {
+                                string imageId = surfaceMap[surfaceId];
+
+                                if (imgMap.ContainsKey(imageId))
+                                    effect.Texture = imgMap[imageId];
+                            }
                         }
                     }
+
                     Materials.Add(effect);
                 }
             }

--- a/OpenMetaverse/ImportExport/ColladalLoader.cs
+++ b/OpenMetaverse/ImportExport/ColladalLoader.cs
@@ -99,10 +99,10 @@ namespace OpenMetaverse.ImportExport
         {
             foreach (var material in Materials)
             {
-				if (!string.IsNullOrEmpty(material.Texture))
-				{
-					LoadImage(material);
-				}
+                if (!string.IsNullOrEmpty(material.Texture))
+                {
+                    LoadImage(material);
+                }
             }
         }
 
@@ -699,7 +699,11 @@ namespace OpenMetaverse.ImportExport
 
             stride += 1;
 
-            if (posSrc == null) return;
+            if (posSrc == null) 
+                return;
+
+           if (list.vcount == "")
+                return;                     // Zero triangles (or quads). StrToArray produces one 0 entry for this so just quit and don't produce any face.
 
             var vcount = StrToArray(list.vcount);
             var idx = StrToArray(list.p);

--- a/OpenMetaverse/ImportExport/ModelUploader.cs
+++ b/OpenMetaverse/ImportExport/ModelUploader.cs
@@ -119,6 +119,8 @@ namespace OpenMetaverse.ImportExport
                         faceMap["offsett"] = 0.0f;
                         faceMap["imagerot"] = 0.0f;
                     }
+                    else
+                        faceMap["image"] = 10000;       // Out of range value to get rid of default "0" which erroneously textures all non-textured faces if there is at least one texture.
 
                     faceList.Add(faceMap);
                 }


### PR DESCRIPTION
Parse the surface and sampler elements required to get from a texture in a phong or lamberth effect to an image. Previous implementation relied on some user-selectable identifiers being the same in texture and image, which is absolutely not guaranteed.

Allow <image> clauses to be picked up from more places than the <library_images> that was implemented, including directly under <effect> and inside <profile_COMMON>.

Speedup of image loading by going through the list of unique materials in the mmeber variable Materials instead of each instance of the use of those materials. So no each image file is read only once as was probably intended from the onset.