### PR TITLE
adding gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,9 @@ compile.bat
 
 [Oo]bj/
 [Bb]in/
-
+.vs/
+OpenMetaverse.GUI/OpenMetaverse.GUI.XML
+OpenMetaverse.StructuredData/OpenMetaverse.StructuredData.XML
+OpenMetaverse.Utilities/OpenMetaverse.Utilities.XML
+OpenMetaverse/OpenMetaverse.XML
+OpenMetaverseTypes/OpenMetaverseTypes.XML


### PR DESCRIPTION
There's a few files & folders that're created when libomv is built that result in libomv being listed as "dirty" when used as a git submodule. 'tis a minor annoyance.